### PR TITLE
doppeltes Body-Tag auf login.pl entfernt

### DIFF
--- a/tmsrc/cgi-bin/Test.pm
+++ b/tmsrc/cgi-bin/Test.pm
@@ -1089,8 +1089,6 @@ ALT=\"kostenloser Vergleich privater Krankenversicherer\" WIDTH=140 HEIGHT=200><
 sub page_footer {
 
 	$page_footer = '
-</body></html>
-
 <!-- Google Tag Manager -->
 <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-KX6R92"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -1101,7 +1099,7 @@ j=d.createElement(s),dl=l!=\'dataLayer\'?\'&l=\'+l:\'\';j.async=true;j.src=
 })(window,document,\'script\',\'dataLayer\',\'GTM-KX6R92\');</script>
 <!-- End Google Tag Manager -->
 
-
+</body></html>
 ';
 	return $page_footer;
 }

--- a/tmsrc/cgi-mod/btm/login.pl
+++ b/tmsrc/cgi-mod/btm/login.pl
@@ -444,8 +444,7 @@ $stunde = $xc . $std;
 
 print <<"(END ERROR HTML)";
 
-
-<body bgcolor=#eeeeee vlink=darkred link=darkred text=black>
+<html>
 <head>
   <title>Bundesliga - TipMaster : LogIn Bereich $leut</title>
 <style type="text/css">
@@ -459,7 +458,7 @@ BODY {OVERFLOW:scroll;OVERFLOW-X:hidden}
 .DEK {POSITION:absolute;VISIBILITY:hidden;Z-INDEX:200;}
 //-->
 </style></head>
-<BODY>
+<body bgcolor="#eeeeee" vlink="darkred" link="darkred" text="black">
 <DIV ID="dek" CLASS="dek"></DIV>
 <SCRIPT TYPE="text/javascript">
 <!--
@@ -1045,8 +1044,6 @@ gelangen Sie <a href=/cgi-bin/btm/anmeldung.pl target=top>hier zur Anmeldung</a>
 (END ERROR HTML)
 }
 
-print $page_footer;
-
 print <<"(END ERROR HTML)";
 
 <font color=darkred>
@@ -1085,6 +1082,8 @@ in <a href="http://community.tipmaster.de/showthread.php?t=27483">diesem Posting
 </td></tr></table>
 
 (END ERROR HTML)
+
+print $page_footer;
 
 select STDOUT;
 $session->writeSession();

--- a/tmsrc/cgi-mod/tmi/login.pl
+++ b/tmsrc/cgi-mod/tmi/login.pl
@@ -611,7 +611,7 @@ $trainer_enc =~ s/ /%20/g;
 #SSO Forum
 print <<"(END ERROR HTML)";
 
-<body bgcolor=#eeeeee vlink=darkred link=darkred text=black>
+<html>
 <head>
   <title>TipMaster international : LogIn Bereich $leut</title>
 <style type="text/css">
@@ -625,7 +625,7 @@ BODY {OVERFLOW:scroll;OVERFLOW-X:hidden}
 .DEK {POSITION:absolute;VISIBILITY:hidden;Z-INDEX:200;}
 //-->
 </style></head>
-<BODY>
+<body bgcolor="#eeeeee" vlink="darkred" link="darkred" text="black">
 <DIV ID="dek" CLASS="dek"></DIV>
 <SCRIPT TYPE="text/javascript">
 <!--
@@ -1429,8 +1429,6 @@ if ( $game > 0 ) {
 
 ################# ENDE TOP TIP ###################################################################
 
-print $page_footer;
-
 print <<"(END ERROR HTML)";
 
 <font color=darkred>
@@ -1464,6 +1462,8 @@ in <a href="http://community.tipmaster.de/showthread.php?t=27483">diesem Posting
 </td></tr></table>
 
 (END ERROR HTML)
+
+print $page_footer;
 
 select STDOUT;
 $session->writeSession();


### PR DESCRIPTION
- Öffnendes html-Tag hinzugefügt.
- Ein body-Tag entfernt.
- Style im verbleibenden body-Tag angegeben.
- footer (schließende Tags) ans Ende gerückt.
- Im footer "Google Tag Manager" in body verschoben. (Ich weiß, manche Frameworks empfehlen nach /body oder gar nach /html eingepflegt zu werden. Macht aber wenig Sinn: html wird dadurch invalid und die Browser heben es eh wieder in den body-Tag um etwas damit anfangen zu können.)