### PR TITLE
Utf8 fix

### DIFF
--- a/tmsrc/cgi-bin/btm/form.pl
+++ b/tmsrc/cgi-bin/btm/form.pl
@@ -83,7 +83,7 @@ $xa = ( $by * 4 ) - 3;
 $xb = $xa + 3;
 if ( $xb > 34 ) { $xb = 34 }
 print
-"<html><title>Tipformular Ergebnisse</title><p align=left><body bgcolor=white text=black link=darkred link=darkred>\n";
+"<html><meta charset="utf-8"><title>Tipformular Ergebnisse</title><p align=left><body bgcolor=white text=black link=darkred link=darkred>\n";
 require "/tmapp/tmsrc/cgi-bin/tag.pl";
 require "/tmapp/tmsrc/cgi-bin/tag_small.pl";
 

--- a/tmsrc/cgi-bin/tmi/form.pl
+++ b/tmsrc/cgi-bin/tmi/form.pl
@@ -83,7 +83,7 @@ $zeit[$y] = $ega[8];
 $xa = ( $by * 4 ) - 3 ;
 $xb = $xa + 3;
 if ( $xb > 34 ) { $xb = 34 }
-print "<html><title>Tipformular Ergebnisse</title><p align=left><body bgcolor=white text=black link=darkred link=darkred>\n";
+print "<html><meta charset="utf-8"><title>Tipformular Ergebnisse</title><p align=left><body bgcolor=white text=black link=darkred link=darkred>\n";
 require "/tmapp/tmsrc/cgi-bin/tag.pl" ;
 require "/tmapp/tmsrc/cgi-bin/tag_small.pl" ;
 


### PR DESCRIPTION
Bitte mal testen, ob man das meta-tag da setzen kann. Oder ist das zu kompliziert, dass jetzt in jeder Datei einzeln zu ändern? Folgende Skripte generieren auch html , die z.B. vo, Firefox falsch dargestellt werden:

cgi-mod/tmi/tips.pl
cgi-mod/btm/tips.pl

cgi-bin/tmi/tipabgabe.pl
cgi-bin/btm/tipabgabe.pl

cgi-bin/tmi/tipabgabe_neu.pl
cgi-bin/btm/tipabgabe_neu.pl

cgi-bin/tmi/tipabgabe_ls.pl

cgi-bin/tmi/tips_fr.pl
cgi-bin/btm/tips_fr.pl

cgi-bin/cl/rundenansicht.pl